### PR TITLE
Bugfix/tool bar

### DIFF
--- a/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
+++ b/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
@@ -1104,6 +1104,7 @@
 				D9CE2D5E2565C06E00DF4D2A /* NoteAssignerResultsTableViewCell.swift */,
 				D925934D255986F1000529B4 /* InputViewTipsStack.swift */,
 				A7C057C425420F260023A370 /* NotesToolbar.swift */,
+				E44C1885260031A3005CCF40 /* NotesView.swift */,
 			);
 			path = Notes;
 			sourceTree = "<group>";
@@ -1152,7 +1153,6 @@
 				D9CE2D312565C00A00DF4D2A /* Accessories */,
 				D9CE2D362565C00A00DF4D2A /* Controllers */,
 				D9CE2D3C2565C00A00DF4D2A /* Protocols */,
-				E44C1885260031A3005CCF40 /* NotesView.swift */,
 			);
 			path = NotesViewController;
 			sourceTree = "<group>";

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
@@ -23,12 +23,6 @@ internal class NotesPageViewController: UIPageViewController,
     
     private lazy var noteDataSource = NotesPageViewControllerDataSource(notes: notes)
     
-    private lazy var notesToolbar: NotesToolbar = {
-        let toolbar = NotesToolbar(frame: .zero)
-        toolbar.translatesAutoresizingMaskIntoConstraints = false
-        return toolbar
-    }()
-    
     private lazy var noteDelegate = NotesPageViewControllerDelegate { [unowned self] (viewController) in 
         if let notesViewController = viewController as? NotesViewController {
             self.setNotesViewControllers(for: notesViewController)
@@ -56,14 +50,6 @@ internal class NotesPageViewController: UIPageViewController,
                                    target: self,
                                    action: #selector(closeKeyboard))
         return item
-    }()
-
-    private lazy var constraints: [NSLayoutConstraint] = {
-        [
-            notesToolbar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            notesToolbar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            notesToolbar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        ]
     }()
     
     // MARK: - Initializers
@@ -114,7 +100,6 @@ internal class NotesPageViewController: UIPageViewController,
         self.dataSource = noteDataSource
         self.delegate = noteDelegate
         
-        view.addSubview(notesToolbar)
         view.backgroundColor = .rootColor
         
         navigationItem.largeTitleDisplayMode = .never
@@ -136,55 +121,63 @@ internal class NotesPageViewController: UIPageViewController,
         )
     }
     
-    override func viewDidLayoutSubviews() {
-        NSLayoutConstraint.activate(constraints)
-    }
-    
     // MARK: - Functions
     
     ///This method configures que actions performed by the buttons at the notes toolbar 
     private func setupNotesToolbarActions() {
         
-        notesToolbar.deleteNoteTriggered = {
+        #if targetEnvironment(macCatalyst)
+        guard let notesViewController = self.viewControllers?.first as? MacNotesViewController else {
+            return
+        }
+        #else
+        guard let notesViewController = self.viewControllers?.first as? NotesViewController else {
+            return
+        }
+        #endif
+        
+        
+        notesViewController.setDeleteNoteButton {
             self.deleteNote()
         }
         
-        notesToolbar.addImageTriggered = { identifier in
+        notesViewController.setAddImageButton { (identifier) in
             switch identifier {
             case .init("camera"):
-                (self.viewControllers?.first as? NotesViewController)?.presentCameraPicker()
+                notesViewController.presentCameraPicker()
             case .init("library"):
-                (self.viewControllers?.first as? NotesViewController)?.presentPhotoPicker()
+                notesViewController.presentPhotoPicker()
             default:
                 break
             }
         }
+        
         
         #if targetEnvironment(macCatalyst)
         notesToolbar.shareFileTriggered = { identifier in
             switch identifier {
             case .init("note"):
-                (self.viewControllers?.first as? MacNotesViewController)?.exportNote()
+                notesViewController.exportNote()
             case .init("notebook"):
-                (self.viewControllers?.first as? MacNotesViewController)?.exportNotebook()
+                notesViewController.exportNotebook()
             default:
                 break
             }
         }
         #else
-        notesToolbar.shareNoteTriggered = { sender in
+        notesViewController.setShareButton { (sender) in
             guard let userNotebook = self.notebook else {
                 return
             }
             let objectsToShare: [Any] = [userNotebook.createFullDocument()]
             let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
-
+            
             activityVC.popoverPresentationController?.barButtonItem = sender
             self.present(activityVC, animated: true, completion: nil)
         }
         #endif
         
-        notesToolbar.newNoteTriggered = {
+        notesViewController.setCreateButton {
             self.createNote()
         }
     }
@@ -235,7 +228,7 @@ internal class NotesPageViewController: UIPageViewController,
             }
             self.present(deleteAlertController, animated: true, completion: nil)
         }
-        alertControlller.popoverPresentationController?.barButtonItem = notesToolbar.deleteNoteButton
+//        alertControlller.popoverPresentationController?.barButtonItem = notesToolbar.deleteNoteButton
         self.present(alertControlller, animated: true, completion: nil)
     }
     

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
@@ -117,6 +117,8 @@ internal class NotesPageViewController: UIPageViewController,
             name: UIResponder.keyboardWillHideNotification,
             object: nil
         )
+        
+        setupNotesToolbarActions()
     }
     
     // MARK: - Functions
@@ -150,9 +152,8 @@ internal class NotesPageViewController: UIPageViewController,
             }
         }
         
-        
         #if targetEnvironment(macCatalyst)
-        notesToolbar.shareFileTriggered = { identifier in
+        notesViewController.setShareButton { identifier in
             switch identifier {
             case .init("note"):
                 notesViewController.exportNote()

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
@@ -104,9 +104,7 @@ internal class NotesPageViewController: UIPageViewController,
         
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = [notebookIndexButton, presentTipButton]
-        
-        setupNotesToolbarActions()
-        
+                
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow),
@@ -121,19 +119,22 @@ internal class NotesPageViewController: UIPageViewController,
         )
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupNotesToolbarActions()
+    }
+    
     // MARK: - Functions
     
     ///This method configures que actions performed by the buttons at the notes toolbar 
     private func setupNotesToolbarActions() {
         
         #if targetEnvironment(macCatalyst)
-        guard let notesViewController = self.viewControllers?.first as? MacNotesViewController else {
+        guard let notesViewController = notesViewControllers[index] as? MacNotesViewController else {
             return
         }
         #else
-        guard let notesViewController = self.viewControllers?.first as? NotesViewController else {
-            return
-        }
+        let notesViewController = self.notesViewControllers[self.index]
         #endif
         
         
@@ -228,7 +229,7 @@ internal class NotesPageViewController: UIPageViewController,
             }
             self.present(deleteAlertController, animated: true, completion: nil)
         }
-//        alertControlller.popoverPresentationController?.barButtonItem = notesToolbar.deleteNoteButton
+        alertControlller.popoverPresentationController?.barButtonItem = viewController.customView.notesToolbar.deleteNoteButton
         self.present(alertControlller, animated: true, completion: nil)
     }
     

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes Page View/NotesPageViewController.swift
@@ -119,22 +119,19 @@ internal class NotesPageViewController: UIPageViewController,
         )
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        setupNotesToolbarActions()
-    }
-    
     // MARK: - Functions
     
     ///This method configures que actions performed by the buttons at the notes toolbar 
     private func setupNotesToolbarActions() {
         
         #if targetEnvironment(macCatalyst)
-        guard let notesViewController = notesViewControllers[index] as? MacNotesViewController else {
+        guard let notesViewController = self.viewControllers?.first as? MacNotesViewController else {
             return
         }
         #else
-        let notesViewController = self.notesViewControllers[self.index]
+        guard let notesViewController = self.viewControllers?.first as? NotesViewController else {
+            return
+        }
         #endif
         
         
@@ -212,7 +209,7 @@ internal class NotesPageViewController: UIPageViewController,
             message: "Warning".localized(),
             preferredStyle: .actionSheet).makeDeleteConfirmation(dataType: .note) { _ in
             let deleteAlertController = UIAlertController(
-                title: "Delete note confirmation".localized(),
+                title: "Delete Note confirmation".localized(),
                 message: "Warning".localized(),
                 preferredStyle: .alert).makeDeleteConfirmation(dataType: .note) { _ in
                 do {
@@ -275,6 +272,8 @@ internal class NotesPageViewController: UIPageViewController,
         if let viewController = viewControllers.count > 2 ? notesViewControllers[1] : viewControllerToBePresented {
             setViewControllers([viewController], direction: .forward, animated: false)
         }
+        
+        setupNotesToolbarActions()
     }
     
     ///This method updates the current notes being displayed by the page view

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Pedro Giuliano Farina. All rights reserved.
 //
 
+#if !targetEnvironment(macCatalyst)
 import UIKit
 import Database
 
@@ -29,6 +30,18 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
                                    action: #selector(closeKeyboard))
         item.tintColor = UIColor.actionColor
         return item
+    }()
+    
+    internal lazy var markupConfig: MarkdownBarConfiguration = {
+        let mrkConf = MarkdownBarConfiguration(owner: self.customView.textView)
+        mrkConf.observer = self
+        return mrkConf
+    }()
+    
+    
+    private lazy var markupNavigationView: MarkdownNavigationView = {
+        let mrkView = MarkdownNavigationView(frame: .zero, configurations: markupConfig)
+        return mrkView
     }()
     
     // MARK: - Initializers
@@ -93,6 +106,11 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
             activityVC.popoverPresentationController?.barButtonItem = sender
             self.present(activityVC, animated: true, completion: nil)
         }
+        
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            navigationItem.largeTitleDisplayMode = .never
+            navigationItem.titleView = markupNavigationView
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -127,3 +145,4 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
         self.navigationController?.pushViewController(destination, animated: true)
     }
 }
+#endif

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -53,6 +53,46 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItems = [addNoteBarButton]
+        self.customView.notesToolbar.customizeButtons(with: false)
+        
+        self.setDeleteNoteButton {
+            let alertControlller = UIAlertController(
+                title: "Delete Note confirmation".localized(),
+                message: "Warning".localized(),
+                preferredStyle: .actionSheet).makeDeleteConfirmation(dataType: .note) { _ in
+                let deleteAlertController = UIAlertController(
+                    title: "Delete note confirmation".localized(),
+                    message: "Warning".localized(),
+                    preferredStyle: .alert).makeDeleteConfirmation(dataType: .note) { _ in
+                        self.dismiss(animated: true, completion: nil)
+                }
+                self.present(deleteAlertController, animated: true, completion: nil)
+            }
+            alertControlller.popoverPresentationController?.barButtonItem = self.customView.notesToolbar.deleteNoteButton
+            self.present(alertControlller, animated: true, completion: nil)
+        }
+        
+        self.setAddImageButton { (identifier) in
+            switch identifier {
+            case .init("camera"):
+                self.presentCameraPicker()
+            case .init("library"):
+                self.presentPhotoPicker()
+            default:
+                break
+            }
+        }
+        
+        self.setShareButton { (sender) in
+            guard let userNotebook = self.notebook else {
+                return
+            }
+            let objectsToShare: [Any] = [userNotebook.createFullDocument()]
+            let activityVC = UIActivityViewController(activityItems: objectsToShare, applicationActivities: nil)
+            
+            activityVC.popoverPresentationController?.barButtonItem = sender
+            self.present(activityVC, animated: true, completion: nil)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -36,6 +36,7 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
     internal init(note: NoteEntity, notebook: NotebookEntity? = nil, workspaces: @escaping () -> [WorkspaceEntity]) {
         self.workspaces = workspaces
         super.init(looseNote: note, notebook: notebook)
+        print(self.customView.keyboardToolbar)
     }
 
     internal required convenience init?(coder: NSCoder) {

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -61,7 +61,7 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
                 message: "Warning".localized(),
                 preferredStyle: .actionSheet).makeDeleteConfirmation(dataType: .note) { _ in
                 let deleteAlertController = UIAlertController(
-                    title: "Delete note confirmation".localized(),
+                    title: "Delete Note confirmation".localized(),
                     message: "Warning".localized(),
                     preferredStyle: .alert).makeDeleteConfirmation(dataType: .note) { _ in
                         self.dismiss(animated: true, completion: nil)

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -49,7 +49,6 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
     internal init(note: NoteEntity, notebook: NotebookEntity? = nil, workspaces: @escaping () -> [WorkspaceEntity]) {
         self.workspaces = workspaces
         super.init(looseNote: note, notebook: notebook)
-        print(self.customView.keyboardToolbar)
     }
 
     internal required convenience init?(coder: NSCoder) {
@@ -66,6 +65,7 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItems = [addNoteBarButton]
+        self.customView.textView.allowsEditingTextAttributes = true
         self.customView.notesToolbar.customizeButtons(with: false)
         
         self.setDeleteNoteButton {
@@ -125,7 +125,7 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
     func dismissLooseNoteViewController() {
         self.navigationController?.popViewController(animated: true)
     }
-    
+        
     // MARK: - IBActions functions
     
     @IBAction private func closeKeyboard() {
@@ -143,6 +143,20 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
             imageBoxes: imageBoxes
         )
         self.navigationController?.pushViewController(destination, animated: true)
+    }
+
+// MARK: - MarkupToolBarObserver
+    
+    ///This method opens the pop over when the button is pressed
+    @objc internal override func openPopOver() {
+        let markupContainerViewController = MarkupContainerViewController(owner: self.customView.textView,
+                                                                          viewController: self,
+                                                                          size: .init(width: 400, height: 110))
+
+        markupContainerViewController.modalPresentationStyle = .popover
+        markupContainerViewController.popoverPresentationController?.sourceView = markupNavigationView.barButtonItems[.format]
+        markupContainerViewController.popoverPresentationController?.passthroughViews = [self.customView.textView]
+        present(markupContainerViewController, animated: true)
     }
 }
 #endif

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
@@ -125,6 +125,20 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
         self.navigationController?.popViewController(animated: true)
     }
     
+    // MARK: - MarkupToolBarObserver
+    
+    ///This method opens the pop over when the button is pressed
+    @objc internal override func openPopOver() {
+        let markupContainerViewController = MarkupContainerViewController(owner: self.customView.textView,
+                                                                          viewController: self,
+                                                                          size: .init(width: 400, height: 110))
+
+        markupContainerViewController.modalPresentationStyle = .popover
+        markupContainerViewController.popoverPresentationController?.sourceView = markupNavigationView.barButtonItems[.format]
+        markupContainerViewController.popoverPresentationController?.passthroughViews = [self.customView.textView]
+        present(markupContainerViewController, animated: true)
+    }
+    
     // MARK: - IBActions functions
     
     @IBAction private func closeKeyboard() {

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
@@ -33,6 +33,19 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
         return item
     }()
     
+    internal lazy var markupConfig: MarkdownBarConfiguration = {
+        let mrkConf = MarkdownBarConfiguration(owner: self.customView.textView)
+        mrkConf.observer = self
+        return mrkConf
+    }()
+    
+    
+    private lazy var markupNavigationView: MarkdownNavigationView = {
+        let mrkView = MarkdownNavigationView(frame: .zero, configurations: markupConfig)
+        mrkView.backgroundColor = .clear
+        return mrkView
+    }()
+    
     // MARK: - Initializers
     
     internal init(note: NoteEntity, notebook: NotebookEntity? = nil, workspaces: @escaping () -> [WorkspaceEntity]) {
@@ -47,7 +60,13 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
             return nil
         }
         self.init(note: note, notebook: coder.decodeObject(forKey: "notebook") as? NotebookEntity, workspaces: workspaces)
-        
+    }
+
+    // MARK: - Override functions
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.rightBarButtonItems = [addNoteBarButton]
         self.customView.notesToolbar.customizeButtons(with: false)
         
         self.setDeleteNoteButton {
@@ -78,7 +97,7 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
             }
         }
         
-        self.shareFileTriggered = { (identifier) in
+        self.setShareButton { identifier in
             switch identifier {
             case .init("note"):
                 self.exportNote()
@@ -88,13 +107,9 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
                 break
             }
         }
-    }
-
-    // MARK: - Override functions
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationItem.rightBarButtonItems = [addNoteBarButton]
+        
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.titleView = markupNavigationView
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacLooseNoteViewController.swift
@@ -47,6 +47,47 @@ class MacLooseNoteViewController: MacNotesViewController, NoteAssignerObserver {
             return nil
         }
         self.init(note: note, notebook: coder.decodeObject(forKey: "notebook") as? NotebookEntity, workspaces: workspaces)
+        
+        self.customView.notesToolbar.customizeButtons(with: false)
+        
+        self.setDeleteNoteButton {
+            let alertControlller = UIAlertController(
+                title: "Delete Note confirmation".localized(),
+                message: "Warning".localized(),
+                preferredStyle: .actionSheet).makeDeleteConfirmation(dataType: .note) { _ in
+                let deleteAlertController = UIAlertController(
+                    title: "Delete note confirmation".localized(),
+                    message: "Warning".localized(),
+                    preferredStyle: .alert).makeDeleteConfirmation(dataType: .note) { _ in
+                        self.dismiss(animated: true, completion: nil)
+                }
+                self.present(deleteAlertController, animated: true, completion: nil)
+            }
+            alertControlller.popoverPresentationController?.barButtonItem = self.customView.notesToolbar.deleteNoteButton
+            self.present(alertControlller, animated: true, completion: nil)
+        }
+        
+        self.setAddImageButton { (identifier) in
+            switch identifier {
+            case .init("camera"):
+                self.presentCameraPicker()
+            case .init("library"):
+                self.presentPhotoPicker()
+            default:
+                break
+            }
+        }
+        
+        self.shareFileTriggered = { (identifier) in
+            switch identifier {
+            case .init("note"):
+                self.exportNote()
+            case .init("notebook"):
+                self.exportNotebook()
+            default:
+                break
+            }
+        }
     }
 
     // MARK: - Override functions

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacNotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacNotesViewController.swift
@@ -35,7 +35,7 @@ class MacNotesViewController: NotesViewController {
         }
     }()
     
-    @IBAction internal func importImage() {
+    @objc internal override func importImage() {
         let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [.image])
         documentPicker.delegate = documentPickerDelegate
         documentPicker.allowsMultipleSelection = false

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacNotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/MacNotesViewController.swift
@@ -89,6 +89,10 @@ class MacNotesViewController: NotesViewController {
         }
         exportPDF(notebook.createFullDocument(), title: notebook.name)
     }
+    
+    internal func setShareButton(_ action: @escaping (UIAction.Identifier) -> Void) {
+        self.customView.notesToolbar.shareFileTriggered = action
+    }
 
 }
 #endif

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -362,6 +362,24 @@ internal class NotesViewController: UIViewController,
         customView.textView.insertText("\n" + text + "\n")
     }
     
+    internal func setDeleteNoteButton(_ action: @escaping () -> Void) {
+        self.customView.notesToolbar.deleteNoteTriggered = action
+    }
+    
+    internal func setAddImageButton(_ action: @escaping (UIAction.Identifier) -> Void) {
+        self.customView.notesToolbar.addImageTriggered = action
+    }
+    
+    #if !targetEnvironment(macCatalyst)
+    internal func setShareButton(_ action: @escaping (UIBarButtonItem) -> Void) {
+        self.customView.notesToolbar.shareNoteTriggered = action
+    }
+    #endif
+    
+    internal func setCreateButton(_ action: @escaping () -> Void) {
+        self.customView.notesToolbar.newNoteTriggered = action
+    }
+    
     // MARK: - Uptade exclusion path frames
     
     internal func updateExclusionPaths() {

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -581,6 +581,11 @@ extension NotesViewController: MarkupToolBarObserver {
         self.showImagePickerController(sourceType: .camera)
         #endif
     }
+    
+    ///This method opens the pop over when the button is pressed
+    @objc internal func openPopOver() {}
+    
+    @objc internal func importImage() {}
 }
 
 // MARK: - SensitiveContentController

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -129,7 +129,6 @@ internal class NotesViewController: UIViewController,
     
     override func loadView() {
         let customView = CustomView()
-//        customView.delegate = self
         view = customView
     }
     

--- a/MacroPepelelipa/MacroPepelelipa/View/Notes/NotesToolbar.swift
+++ b/MacroPepelelipa/MacroPepelelipa/View/Notes/NotesToolbar.swift
@@ -110,7 +110,7 @@ internal class NotesToolbar: UIToolbar {
     internal override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setUpButtons()
+        setUpButtons(true)
         
         self.sizeToFit()
         self.tintColor = .actionColor
@@ -127,15 +127,23 @@ internal class NotesToolbar: UIToolbar {
         self.init(frame: frame)
     }
     
-    private func setUpButtons() {
+    private func setUpButtons(_ hasNewNoteButton: Bool) {
         
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         
         if UIDevice.current.userInterfaceIdiom == .phone {
-            self.items = [deleteNoteButton, flexibleSpace, addImageButton, flexibleSpace, shareNoteButton, flexibleSpace, newNoteButton]
+            self.items = [deleteNoteButton, flexibleSpace, addImageButton, flexibleSpace, shareNoteButton]
         } else {
-            self.items = [deleteNoteButton, flexibleSpace, shareNoteButton, flexibleSpace, newNoteButton]
+            self.items = [deleteNoteButton, flexibleSpace, shareNoteButton]
         }
+        
+        if hasNewNoteButton {
+            self.items?.append(contentsOf: [flexibleSpace, newNoteButton])
+        }
+    }
+    
+    internal func customizeButtons(with newNoteButton: Bool) {
+        self.setUpButtons(newNoteButton)
     }
     
     // MARK: - IBActions Functions

--- a/MacroPepelelipa/MacroPepelelipa/View/Notes/NotesView.swift
+++ b/MacroPepelelipa/MacroPepelelipa/View/Notes/NotesView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import MarkdownText
 
-class NotesView: UIView, MarkdownFormatViewReceiver {
+internal class NotesView: UIView, MarkdownFormatViewReceiver {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -86,6 +86,12 @@ class NotesView: UIView, MarkdownFormatViewReceiver {
         return toolBar
     }()
     
+    internal lazy var notesToolbar: NotesToolbar = {
+        let toolbar = NotesToolbar(frame: .zero)
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        return toolbar
+    }()
+    
     internal private(set) lazy var customConstraints: [NSLayoutConstraint] = {
         [
             textField.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 20),
@@ -96,7 +102,11 @@ class NotesView: UIView, MarkdownFormatViewReceiver {
             textView.topAnchor.constraint(equalTo: self.textField.bottomAnchor, constant: 20),
             textView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
-            textViewBottomConstraint
+            textViewBottomConstraint,
+            
+            notesToolbar.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
+            notesToolbar.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
+            notesToolbar.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
         ]
     }()
     
@@ -106,6 +116,7 @@ class NotesView: UIView, MarkdownFormatViewReceiver {
         addSubview(textField)
         addSubview(textView)
         addSubview(markupContainerView)
+        addSubview(notesToolbar)
     }
     
     // MARK: - Internal methods


### PR DESCRIPTION
# PR Description

#### Proposed changes

Added ToolBar on LooseNoteViewController and MacLooseNoteViewController. The ToolBar doesn't include a creation button, since the team agreed it didn't make sense for a single note.

While testing, I noted that it is not possible to add an image to a Loose Note, I created a new task on ClickUp so we can evaluate it later.

#### Kind of Change
What kind of change does your code introduce? Put an ```x``` in the box that applies.
**NOTE: Please do not create MRs with different purposes. Each MR must have a single purpose: Hotfix, New Feature, or Structural Change.**

- [x] Hotfix.
- [ ] New Feature.
- [ ] Structural Change.

#### Checklist

Put an ```x``` in the boxes that apply.

### This MR follows the base conventions of the project:
- [x] Does not add commented code.
- [x] Does not add code with ```print```.
- [x] Documentation have been added / updated as needed.
- [ ] New Strings are located in ```*.strings``` file.
- [x] IBOutlets and delegates should be weak to avoid retain cycles.
