### PR TITLE
Bugfix/loose note persistence

### DIFF
--- a/MacroPepelelipa/Database/Data/DataManager.swift
+++ b/MacroPepelelipa/Database/Data/DataManager.swift
@@ -334,17 +334,17 @@ public class DataManager {
         guard let noteObject = note as? NoteObject else {
             throw NoteError.failedToParse
         }
+        
+        #if !DEVELOP
         guard let ckNotebook = notebookObject.cloudKitNotebook else {
             throw NotebookError.notebookWasNull
         }
         let ckNote = cloudKitController.createNote(in: ckNotebook, id: try note.getID())
-        #if !DEVELOP
         ckNote <- noteObject.coreDataNote
         ckNote.setNotebook(ckNotebook)
         ckNotebook.appendNote(ckNote)
-        #endif
-
         noteObject.cloudKitNote = ckNote
+        #endif
 
         noteObject.setNotebook(notebookObject)
         try note.save()

--- a/MacroPepelelipa/Database/EntityProtocols/PersistentEntity.swift
+++ b/MacroPepelelipa/Database/EntityProtocols/PersistentEntity.swift
@@ -6,6 +6,6 @@
 //  Copyright © 2020 Pedro Giuliano Farina. All rights reserved.
 //
 
-public protocol PersistentEntity: class {
+public protocol PersistentEntity: AnyObject {
     func getID() throws -> UUID
 }

--- a/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
+++ b/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		1EE652C72525049E0015E3D4 /* MarkdownToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE652C62525049E0015E3D4 /* MarkdownToggleButton.swift */; };
 		1EFA49CE252D15C500602904 /* MarkdownNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA49CD252D15C500602904 /* MarkdownNavigationView.swift */; };
 		5832E2F5260A86EF0003D783 /* MacLooseNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5832E2F4260A86EF0003D783 /* MacLooseNoteViewController.swift */; };
+		8DDFEEAC264C55EC00AB9830 /* NoteWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDFEEAB264C55EC00AB9830 /* NoteWrapper.swift */; };
 		A7026CDF25659B2400B8FC78 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C21B33254B55BB0061CCBA /* Font.swift */; };
 		A71E2C1D2538EEB8000DA164 /* NotesPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71E2C1B2538EEB8000DA164 /* NotesPageViewController.swift */; };
 		A71E2C1E2538EEB8000DA164 /* NotesPageViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71E2C1C2538EEB8000DA164 /* NotesPageViewControllerDelegate.swift */; };
@@ -406,6 +407,7 @@
 		1EFA49CD252D15C500602904 /* MarkdownNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownNavigationView.swift; sourceTree = "<group>"; };
 		5832E2F4260A86EF0003D783 /* MacLooseNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacLooseNoteViewController.swift; sourceTree = "<group>"; };
 		58E145A32636F9EC0048C6AA /* MacroPepelelipaDevelop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MacroPepelelipaDevelop.entitlements; sourceTree = "<group>"; };
+		8DDFEEAB264C55EC00AB9830 /* NoteWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWrapper.swift; sourceTree = "<group>"; };
 		A71E2C1B2538EEB8000DA164 /* NotesPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotesPageViewController.swift; sourceTree = "<group>"; };
 		A71E2C1C2538EEB8000DA164 /* NotesPageViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotesPageViewControllerDelegate.swift; sourceTree = "<group>"; };
 		A71E2C202538EF51000DA164 /* NotesPageViewControllerDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotesPageViewControllerDataSource.swift; path = MacroPepelelipa/Model/Notes/NotesPageViewControllerDataSource.swift; sourceTree = SOURCE_ROOT; };
@@ -996,6 +998,7 @@
 				0221BCF425115E150055A2E5 /* Workspace */,
 				A7BDD6082514066700DDB6A0 /* NotebookIndex */,
 				0285DF2025840E4F009CE5A9 /* SensitiveContentController.swift */,
+				8DDFEEAB264C55EC00AB9830 /* NoteWrapper.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1630,6 +1633,7 @@
 				024C5BB4252E41D8009549CE /* ColorSelectionCollectionViewDelegate.swift in Sources */,
 				02AD78F225475C5800C87D2B /* EditableCollectionView.swift in Sources */,
 				1E9EF4A925225B9B00CC623B /* TextEditingDelegateObserver.swift in Sources */,
+				8DDFEEAC264C55EC00AB9830 /* NoteWrapper.swift in Sources */,
 				D9CE2D4B2565C00A00DF4D2A /* NoteAssignerObserver.swift in Sources */,
 				02CD7CA12523B48900A140A3 /* WorkspacesCollectionViewDelegate.swift in Sources */,
 				02919F4825531BFA00C03E27 /* App String Extensions.swift in Sources */,

--- a/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
+++ b/MacroPepelelipa/MacroPepelelipa.xcodeproj/project.pbxproj
@@ -2139,7 +2139,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = PEPELELIPA.Macro.develop.farina;
+				PRODUCT_BUNDLE_IDENTIFIER = PEPELELIPA.Macro.develop;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -76,7 +76,19 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
                     title: "Delete Note confirmation".localized(),
                     message: "Warning".localized(),
                     preferredStyle: .alert).makeDeleteConfirmation(dataType: .note) { _ in
-                        self.dismiss(animated: true, completion: nil)
+                        if let noteEntity = self.note {
+                            do {
+                                try DataManager.shared().deleteNote(noteEntity)
+                                self.dismiss(animated: true, completion: nil)
+                            } catch {
+                                let title = "Could not delete this note".localized()
+                                let message = "An error occurred while deleting this instance on the database".localized()
+                                
+                                ConflictHandlerObject().genericErrorHandling(title: title, message: message)
+                            }
+                        } else {
+                            self.dismiss(animated: true, completion: nil)
+                        }
                 }
                 self.present(deleteAlertController, animated: true, completion: nil)
             }

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/LooseNoteViewController.swift
@@ -38,7 +38,6 @@ internal class LooseNoteViewController: NotesViewController, NoteAssignerObserve
         return mrkConf
     }()
     
-    
     private lazy var markupNavigationView: MarkdownNavigationView = {
         let mrkView = MarkdownNavigationView(frame: .zero, configurations: markupConfig)
         return mrkView

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NoteAssignerViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NoteAssignerViewController.swift
@@ -14,9 +14,13 @@ import MarkdownText
 class NoteAssignerViewController: UIViewController, 
                                   NoteAssignerNotebookObserver {
     
+    // MARK: - Internal properties
+    
     internal weak var note: NoteEntity?
     
     internal weak var observer: NoteAssignerObserver?
+    
+    // MARK: - Private properties
     
     private var workspaces: () -> ([WorkspaceEntity])
     
@@ -64,7 +68,7 @@ class NoteAssignerViewController: UIViewController,
         return label
     }()
     
-    private let  selectedNotebookLbl: UILabel  = {
+    private let selectedNotebookLbl: UILabel  = {
         let label = UILabel()
         
         label.text = "Selected Notebook".localized()
@@ -242,6 +246,8 @@ class NoteAssignerViewController: UIViewController,
         ]
     }()
     
+    // MARK: - View Controller Methods
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor.backgroundColor
@@ -287,6 +293,8 @@ class NoteAssignerViewController: UIViewController,
         chooseAnotherNotebookBtn.layer.cornerRadius = chooseAnotherNotebookBtn.frame.height / 2
         addToNotebookBtn.layer.cornerRadius = addToNotebookBtn.frame.height / 2
     }
+    
+    // MARK: - Initializers
         
     init(note: NoteEntity?, lastNotebook: NotebookEntity?, workspaces: @escaping () -> [WorkspaceEntity]) {
         self.note = note
@@ -307,6 +315,8 @@ class NoteAssignerViewController: UIViewController,
         self.init(note: note, lastNotebook: lastNotebook, workspaces: workspaces)
     }
     
+    // MARK: - Private methods
+    
     private func addSubsViews() {
         self.view.addSubview(noteNameLbl)
         self.view.addSubview(saveExplanationLbl)
@@ -317,6 +327,8 @@ class NoteAssignerViewController: UIViewController,
         self.view.addSubview(chooseAnotherNotebookBtn)
         self.view.addSubview(addToNotebookBtn)
     }
+    
+    // MARK: - Internal methods
     
     internal func selectedNotebook(notebook: NotebookEntity, controller: UIViewController?) {
         self.lastNotebook = notebook
@@ -347,6 +359,9 @@ class NoteAssignerViewController: UIViewController,
                                 
                                 ConflictHandlerObject().genericErrorHandling(title: title, message: message)
                             }
+                        } else {
+                            self.dismiss(animated: true, completion: nil)
+                            observer?.dismissLooseNoteViewController()
                         }
                 }
                 self.present(deleteAlertController, animated: true, completion: nil)

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NoteAssignerViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NoteAssignerViewController.swift
@@ -380,7 +380,7 @@ class NoteAssignerViewController: UIViewController,
             } catch {
                 let title = "Could note assign the note to the notebook".localized()
                 let message = "The app could not assign the note to the notebook".localized() + noteEntity.title.string
-                
+
                 ConflictHandlerObject().genericErrorHandling(title: title, message: message)
             }
         }

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -62,8 +62,8 @@ internal class NotesViewController: UIViewController,
     internal lazy var textView: MarkdownTextView = self.customView.textView
     internal private(set) lazy var noteContentHandler = NoteContentHandler()
 
-    internal weak var note: NoteEntity?
-    internal weak var notebook: NotebookEntity?
+    internal var note: NoteEntity?
+    internal var notebook: NotebookEntity?
     
     private lazy var resizeHandleFunctions = ResizeHandleFunctions(owner: self)
     private lazy var boxViewInteractions = BoxViewInteractions(resizeHandleReceiver: self, boxViewReceiver: self, center: Float(self.view.frame.width/2))
@@ -176,10 +176,21 @@ internal class NotesViewController: UIViewController,
         }
         updateExclusionPaths()
         
-        if !((try? notebook?.getWorkspace().isEnabled) ?? false) {
-            customView.textView.isEditable = false
-            customView.textView.inputAccessoryView = nil
+        #if targetEnvironment(macCatalyst)
+        if !(self is MacLooseNoteViewController) {
+            if !((try? notebook?.getWorkspace().isEnabled) ?? false) {
+                customView.textView.isEditable = false
+                customView.textView.inputAccessoryView = nil
+            }
         }
+        #else
+        if !(self is LooseNoteViewController) {
+            if !((try? notebook?.getWorkspace().isEnabled) ?? false) {
+                customView.textView.isEditable = false
+                customView.textView.inputAccessoryView = nil
+            }
+        }
+        #endif
         
         let dropInteraction = UIDropInteraction(delegate: dropInteractionDelegate)
         customView.textView.addInteraction(dropInteraction)
@@ -599,4 +610,3 @@ extension NotesViewController: SensitiveContentController {
         isSaving = false
     }
 }
-

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -61,8 +61,16 @@ internal class NotesViewController: UIViewController,
     internal lazy var receiverView: UIView = self.customView
     internal lazy var textView: MarkdownTextView = self.customView.textView
     internal private(set) lazy var noteContentHandler = NoteContentHandler()
-
-    internal var note: NoteEntity?
+    
+    internal var noteWrapper: NoteWrapper
+    internal var note: NoteEntity? {
+        get {
+            noteWrapper.getValue()
+        }
+        set {
+            noteWrapper.setValueTo(newValue)
+        }
+    }
     internal var notebook: NotebookEntity?
     
     private lazy var resizeHandleFunctions = ResizeHandleFunctions(owner: self)
@@ -95,7 +103,7 @@ internal class NotesViewController: UIViewController,
     // MARK: - Initializers
     
     internal init(note: NoteEntity) {
-        self.note = note
+        self.noteWrapper = NoteWrapper(value: note, weak: false)
         super.init(nibName: nil, bundle: nil)
         
         do {
@@ -109,7 +117,7 @@ internal class NotesViewController: UIViewController,
     }
     
     internal init(looseNote: NoteEntity, notebook: NotebookEntity?) {
-        self.note = looseNote
+        self.noteWrapper = NoteWrapper(value: looseNote, weak: true)
         self.notebook = notebook
         super.init(nibName: nil, bundle: nil)
     }

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Notebook/Notes/NotesViewController/Controllers/NotesViewController.swift
@@ -103,7 +103,7 @@ internal class NotesViewController: UIViewController,
     // MARK: - Initializers
     
     internal init(note: NoteEntity) {
-        self.noteWrapper = NoteWrapper(value: note, weak: false)
+        self.noteWrapper = NoteWrapper(value: note, weak: true)
         super.init(nibName: nil, bundle: nil)
         
         do {
@@ -117,7 +117,7 @@ internal class NotesViewController: UIViewController,
     }
     
     internal init(looseNote: NoteEntity, notebook: NotebookEntity?) {
-        self.noteWrapper = NoteWrapper(value: looseNote, weak: true)
+        self.noteWrapper = NoteWrapper(value: looseNote, weak: false)
         self.notebook = notebook
         super.init(nibName: nil, bundle: nil)
     }

--- a/MacroPepelelipa/MacroPepelelipa/Controller/Workspace/WorkspaceSelection/WorkspaceSelectionViewController.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Controller/Workspace/WorkspaceSelection/WorkspaceSelectionViewController.swift
@@ -214,6 +214,7 @@ internal class WorkspaceSelectionViewController: UIViewController,
         super.viewWillAppear(animated)
         collectionDelegate.frame = view.frame
         collectionView.collectionViewLayout.invalidateLayout()
+        self.enableLooseNote(collectionDataSource.hasNotebooks())
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -464,6 +465,14 @@ internal class WorkspaceSelectionViewController: UIViewController,
                 self.emptyScreenView.isHidden = true
             }
         })
+    }
+    
+    /**
+     This method enables or disenables the button to add a Loose Note.
+     - Parameter shouldBeEnabled: A boolean indicating if the button should or not be enabled. It is true by default.
+     */
+    internal func enableLooseNote(_ shouldBeEnabled: Bool = true) {
+        self.btnAddLooseNote.isEnabled = shouldBeEnabled
     }
     
     // MARK: - EntityObserver functions

--- a/MacroPepelelipa/MacroPepelelipa/Model/NoteWrapper.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Model/NoteWrapper.swift
@@ -1,0 +1,35 @@
+//
+//  NoteWrapper.swift
+//  MacroPepelelipa
+//
+//  Created by Pedro Farina on 12/05/21.
+//  Copyright © 2021 Pedro Giuliano Farina. All rights reserved.
+//
+
+import Database
+
+internal struct NoteWrapper {
+    private var nonWeakValue: NoteEntity?
+    private weak var weakValue: NoteEntity?
+    private let weak: Bool
+
+    internal init(value: NoteEntity, weak: Bool) {
+        if weak {
+            weakValue = value
+        } else {
+            nonWeakValue = value
+        }
+        self.weak = weak
+    }
+
+    internal func getValue() -> NoteEntity? {
+        return weakValue ?? nonWeakValue
+    }
+    internal mutating func setValueTo(_ value: NoteEntity?) {
+        if weak {
+            weakValue = value
+        } else {
+            nonWeakValue = value
+        }
+    }
+}

--- a/MacroPepelelipa/MacroPepelelipa/Model/Workspace/WorkspacesCollectionViewDataSource.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Model/Workspace/WorkspacesCollectionViewDataSource.swift
@@ -83,7 +83,11 @@ internal class WorkspacesCollectionViewDataSource: NSObject,
         var notebooks = [NotebookEntity]()
         workspaces.forEach({ notebooks.append(contentsOf: $0.notebooks) })
         
-        return notebooks.first(where: { (try? $0.getID())?.uuidString == identifier })
+        if let lastEditedNotebook = notebooks.first(where: { (try? $0.getID())?.uuidString == identifier }) {
+            return lastEditedNotebook
+        }
+        
+        return notebooks.first
     }
     
     /**

--- a/MacroPepelelipa/MacroPepelelipa/Model/Workspace/WorkspacesCollectionViewDataSource.swift
+++ b/MacroPepelelipa/MacroPepelelipa/Model/Workspace/WorkspacesCollectionViewDataSource.swift
@@ -48,11 +48,7 @@ internal class WorkspacesCollectionViewDataSource: NSObject,
         guard let viewController = viewController as? WorkspaceSelectionViewController else {
             return
         }
-        if workspaces.isEmpty {
-            viewController.switchEmptyScreenView()
-        } else {
-            viewController.switchEmptyScreenView(shouldBeHidden: true)
-        }
+        viewController.switchEmptyScreenView(shouldBeHidden: !workspaces.isEmpty)
     }
     
     // MARK: - UICollectionViewDataSource functions
@@ -88,6 +84,17 @@ internal class WorkspacesCollectionViewDataSource: NSObject,
         workspaces.forEach({ notebooks.append(contentsOf: $0.notebooks) })
         
         return notebooks.first(where: { (try? $0.getID())?.uuidString == identifier })
+    }
+    
+    /**
+     This method checks if there are any notebooks in the workspaces.
+     - Returns: True if any notebooks were found, false if none was found.
+     */
+    internal func hasNotebooks() -> Bool {
+        for workspace in workspaces where !workspace.notebooks.isEmpty {
+            return true
+        }
+        return false
     }
     
     // MARK: - EntityObserver functions
@@ -134,6 +141,7 @@ internal class WorkspacesCollectionViewDataSource: NSObject,
         }
         if workspaces.isEmpty {
             viewController.switchEmptyScreenView()
+            viewController.enableLooseNote(false)
         }
     }
 }


### PR DESCRIPTION
# PR Description

#### Proposed changes

Fixed different bugs related to the persistence of the loose note. Now, the LooseNoteViewController has a non-weak reference to the NoteEntity. Also, it is not possible to create a loose note if there are no notebooks in the shelves, in order to avoid problems when saving the note.

#### Kind of Change
What kind of change does your code introduce? Put an ```x``` in the box that applies.
**NOTE: Please do not create MRs with different purposes. Each MR must have a single purpose: Hotfix, New Feature, or Structural Change.**

- [x] Hotfix.
- [ ] New Feature.
- [ ] Structural Change.

#### Checklist

Put an ```x``` in the boxes that apply.

### This MR follows the base conventions of the project:
- [x] Does not add commented code.
- [x] Does not add code with ```print```.
- [x] Documentation have been added / updated as needed.
- [ ] New Strings are located in ```*.strings``` file.
- [ ] IBOutlets and delegates should be weak to avoid retain cycles.
