### PR TITLE
Mac markdown bug fixing

### DIFF
--- a/MacroPepelelipa/MacroPepelelipa/View/Markdown/MarkdownTextField.swift
+++ b/MacroPepelelipa/MacroPepelelipa/View/Markdown/MarkdownTextField.swift
@@ -25,6 +25,11 @@ internal class MarkdownTextField: UITextField {
         
         self.translatesAutoresizingMaskIntoConstraints = false
         
+        #if targetEnvironment(macCatalyst)
+        self.autocorrectionType = .no
+        self.spellCheckingType = .no
+        #endif
+        
         addPaddingSpace(space: paddingSpace)
     }
     


### PR DESCRIPTION
# PR Description

#### Proposed changes

Because of the issues we were having with the text view on the Mac, autocorrect and spell check were both disabled on Mac Catalyst.
**Note: this is a temporary fix to this issue. Users should be able to use autocorrect on every platform.**

#### Kind of Change
What kind of change does your code introduce? Put an ```x``` in the box that applies.
**NOTE: Please do not create MRs with different purposes. Each MR must have a single purpose: Hotfix, New Feature, or Structural Change.**

- [x] Hotfix.
- [ ] New Feature.
- [ ] Structural Change.

#### Checklist

Put an ```x``` in the boxes that apply.

### This MR follows the base conventions of the project:
- [x] Does not add commented code.
- [x] Does not add code with ```print```.
- [ ] Documentation have been added / updated as needed.
- [ ] New Strings are located in ```*.strings``` file.
- [ ] IBOutlets and delegates should be weak to avoid retain cycles.
